### PR TITLE
feat(RecordedFuture): classify No Risk Observed indicators as Benign

### DIFF
--- a/Packs/RecordedFuture/Integrations/RecordedFuture/RecordedFuture.py
+++ b/Packs/RecordedFuture/Integrations/RecordedFuture/RecordedFuture.py
@@ -16,7 +16,7 @@ STATUS_TO_RETRY = [500, 501, 502, 503, 504]
 # disable insecure warnings
 requests.packages.urllib3.disable_warnings()  # type: ignore
 
-__version__ = "2.5.2"
+__version__ = "2.6.0"
 
 DEFAULT_THRESHOLD_BAD = 65
 DEFAULT_THRESHOLD_SUSPICIOUS = 25
@@ -38,7 +38,7 @@ class IndicatorThresholds:
     suspicious: Dict[str, int]
 
 
-def translate_score(*, score: int, threshold_bad: int, threshold_suspicious: int) -> DBotScoreDetails:
+def translate_score(*, score: int, threshold_bad: int, threshold_suspicious: int, benign: bool = False) -> DBotScoreDetails:
     """Translate Recorded Future score to DBot score and description."""
     # See https://support.recordedfuture.com/hc/en-us/articles/115000894468-Vulnerability-Risk-Rules.  # noqa
     if score >= threshold_bad:
@@ -50,6 +50,13 @@ def translate_score(*, score: int, threshold_bad: int, threshold_suspicious: int
         return DBotScoreDetails(
             score=Common.DBotScore.SUSPICIOUS,
             description=f"Score above {threshold_suspicious}",
+        )
+    elif benign:
+        # The Recorded Future SOAR API reported "No Risk Observed" (noKnownRisk)
+        # for this entity, a deterministic benign signal. See RFPD-112104.
+        return DBotScoreDetails(
+            score=Common.DBotScore.GOOD,
+            description="No Risk Observed",
         )
 
     return DBotScoreDetails(score=Common.DBotScore.NONE, description="")
@@ -112,8 +119,13 @@ def create_indicator(
     score: int,
     description: str = "",
     location: Dict[str, Any] = None,
+    benign: bool = False,
 ) -> Common.Indicator:
-    """Create an Indicator object."""
+    """Create an Indicator object.
+
+    ``benign`` is set by the backend when the SOAR API reports "No Risk Observed"
+    for the entity (RFPD-112104).
+    """
     demisto_params = demisto.params()
 
     if location is None:
@@ -124,6 +136,7 @@ def create_indicator(
         score=score,
         threshold_bad=indicator_thresholds.bad[entity_type],
         threshold_suspicious=indicator_thresholds.suspicious[entity_type],
+        benign=benign,
     )
     dbot_vendor = "Recorded Future v2"
     if entity_type == "ip":
@@ -188,6 +201,30 @@ def create_indicator(
         )
     else:
         raise Exception(f"Could not create indicator for this type of entity: {entity_type}")
+
+
+# Entity types for which the Recorded Future SOAR API exposes a deterministic
+# "No Risk Observed" (noKnownRisk) benign signal. See RFPD-112104.
+BENIGN_ELIGIBLE_TYPES = ("file", "url", "domain")
+
+
+def is_benign_action(action: Dict[str, Any]) -> bool:
+    """Detect the "No Risk Observed" (noKnownRisk) benign signal in a result action.
+
+    The reputation lookup surfaces this signal for ``file`` (hash), ``url`` and
+    ``domain`` entities with a zero risk score. It rides through the existing
+    response as an Evidence entry whose ``ruleid`` is ``noKnownRisk``.
+    """
+    create = action.get("create_indicator") or {}
+    if create.get("entity_type") not in BENIGN_ELIGIBLE_TYPES:
+        return False
+    if create.get("score", 0) != 0:
+        return False
+    outputs = (action.get("CommandResults") or {}).get("outputs")
+    if not isinstance(outputs, dict):
+        return False
+    evidence = outputs.get("Evidence") or []
+    return any(item.get("ruleid") == "noKnownRisk" for item in evidence)
 
 
 # === === === === === === === === === === === === === === ===
@@ -393,7 +430,9 @@ class Actions:
         command_results: List[CommandResults] = []
         for action in result_actions:
             if "create_indicator" in action:
-                indicator = create_indicator(**action["create_indicator"])
+                create_kwargs = dict(action["create_indicator"])
+                create_kwargs["benign"] = is_benign_action(action)
+                indicator = create_indicator(**create_kwargs)
                 if "CommandResults" in action:
                     # Custom CommandResults.
                     command_results_kwargs = action["CommandResults"]
@@ -519,7 +558,7 @@ def main() -> None:  # pragma: no cover
             "X-RF-User-Agent": (
                 f"RecordedFuture.py/{__version__} ({platform.platform()}) "
                 f"XSOAR/{__version__} "
-                f'RFClient/{__version__} (Cortex_XSOAR_{demisto.demistoVersion()["version"]})'
+                f"RFClient/{__version__} (Cortex_XSOAR_{demisto.demistoVersion()['version']})"
             ),
         }
         client = Client(base_url=base_url, verify=verify_ssl, headers=headers, proxy=proxy)

--- a/Packs/RecordedFuture/Integrations/RecordedFuture/RecordedFuture_description.md
+++ b/Packs/RecordedFuture/Integrations/RecordedFuture/RecordedFuture_description.md
@@ -61,4 +61,18 @@ The following data points are collected as part of Collective Insights:
     * Takes a context, such as phishing or malware and one or more IOC as input.
     * Outputs a verdict (true/false) and related evidence (risk rules) for this context.
 
+---
+
+## Verdict / DBotScore mapping
+Reputation and intelligence lookups translate the Recorded Future risk score into a Cortex DBotScore:
+
+| Condition | Verdict | DBotScore |
+| --- | --- | --- |
+| Risk score at or above the configured Malicious threshold | Malicious | 3 (Bad) |
+| Risk score at or above the configured Suspicious threshold | Suspicious | 2 |
+| Recorded Future reports "No Risk Observed" (the `noKnownRisk` risk rule, available for files, URLs and domains) | Benign | 1 (Good) |
+| No risk data available | Unknown | 0 |
+
+Note: the Benign verdict is signal-driven (it requires the "No Risk Observed" risk rule), not threshold-driven. An indicator that simply has no risk data remains Unknown rather than Benign.
+
 Copyright 2020-2022 Recorded Future, Inc.

--- a/Packs/RecordedFuture/Integrations/RecordedFuture/RecordedFuture_test.py
+++ b/Packs/RecordedFuture/Integrations/RecordedFuture/RecordedFuture_test.py
@@ -54,6 +54,59 @@ class TestHelpers:
             assert dbot_score_details.score == expected_score
             assert dbot_score_details.description == expected_description
 
+    def test_translate_score_benign(self):
+        from RecordedFuture import translate_score
+        from CommonServerPython import Common
+
+        # A benign signal with no risk score maps to GOOD.
+        dbot_score_details = translate_score(
+            score=0,
+            threshold_bad=65,
+            threshold_suspicious=25,
+            benign=True,
+        )
+        assert dbot_score_details.score == Common.DBotScore.GOOD
+        assert dbot_score_details.description == "No Risk Observed"
+
+        # Malicious/suspicious scores still take precedence over the benign flag.
+        assert translate_score(score=70, threshold_bad=65, threshold_suspicious=25, benign=True).score == Common.DBotScore.BAD
+        assert (
+            translate_score(score=30, threshold_bad=65, threshold_suspicious=25, benign=True).score == Common.DBotScore.SUSPICIOUS
+        )
+
+        # Without the benign flag, a zero score stays Unknown (None).
+        assert translate_score(score=0, threshold_bad=65, threshold_suspicious=25, benign=False).score == Common.DBotScore.NONE
+
+    def test_is_benign_action(self):
+        from RecordedFuture import is_benign_action
+
+        def action(entity_type, score, evidence):
+            return {
+                "create_indicator": {
+                    "entity": "x",
+                    "entity_type": entity_type,
+                    "score": score,
+                },
+                "CommandResults": {"outputs": {"Evidence": evidence}},
+            }
+
+        no_risk = [{"rule": "No Risk Observed", "ruleid": "noKnownRisk"}]
+        some_risk = [{"rule": "Historically Reported in Threat List", "ruleid": "historicalThreatListMembership"}]
+
+        # noKnownRisk on the eligible types -> benign.
+        assert is_benign_action(action("file", 0, no_risk)) is True
+        assert is_benign_action(action("url", 0, no_risk)) is True
+        assert is_benign_action(action("domain", 0, no_risk)) is True
+
+        # Empty evidence at score 0 is genuine "Unknown", not benign.
+        assert is_benign_action(action("domain", 0, [])) is False
+        # A real risk rule is not benign.
+        assert is_benign_action(action("domain", 24, some_risk)) is False
+        # ip/cve are out of scope even with the signal.
+        assert is_benign_action(action("ip", 0, no_risk)) is False
+        # Defensive: missing CommandResults/outputs must not raise.
+        assert is_benign_action({"create_indicator": {"entity_type": "domain", "score": 0}}) is False
+
     @pytest.mark.parametrize(
         "demisto_params,expected_bad,expected_suspicious",
         [
@@ -1323,6 +1376,7 @@ class TestActions:
             score=15,
             description="mock_description",
             location={"country": "mock_country", "ans": "mock_asn"},
+            benign=False,
         )
 
         assert len(result_actions) == 1
@@ -1380,6 +1434,7 @@ class TestActions:
             entity_type="ip",
             score=15,
             description="mock_indicator_description",
+            benign=False,
         )
 
         assert len(result_actions) == 1

--- a/Packs/RecordedFuture/ReleaseNotes/1_9_0.md
+++ b/Packs/RecordedFuture/ReleaseNotes/1_9_0.md
@@ -1,0 +1,6 @@
+
+#### Integrations
+
+##### Recorded Future v2
+
+- Added a **Benign** verdict for `file`, `url`, and `domain` enrichment. When the Recorded Future SOAR API reports "No Risk Observed" (the `noKnownRisk` risk rule) for an entity, it is now classified with a DBotScore of **Good (1)** instead of **Unknown**.

--- a/Packs/RecordedFuture/pack_metadata.json
+++ b/Packs/RecordedFuture/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "Recorded Future Intelligence",
     "description": "Recorded Future App, this pack is previously known as 'RecordedFuture v2'",
     "support": "partner",
-    "currentVersion": "1.8.11",
+    "currentVersion": "1.9.0",
     "author": "Recorded Future",
     "url": "https://www.recordedfuture.com/support/demisto-integration/",
     "email": "support@recordedfuture.com",


### PR DESCRIPTION
## Summary
Implements RFPD-112104 (follow-up to the RFPD-110587 investigation).

Adds a true **Benign** verdict to the Recorded Future v2 enrichment. When the Recorded Future SOAR enrichment reports the **"No Risk Observed"** (`noKnownRisk`) risk rule for a `file`, `url`, or `domain`, the indicator is now mapped to **DBotScore Good (1)** instead of **Unknown (0)**. Indicators with no risk data remain Unknown.

Detection is entirely client-side in the integration — it reads the `noKnownRisk` evidence already present in the reputation-lookup response (`outputs.Evidence[].ruleid`), so no BFI change is required and older deployments are unaffected.

## Tests
Added two tests:
- `TestHelpers::test_translate_score_benign`
- `TestHelpers::test_is_benign_action`
Updated two `_process_result_actions` tests with the new `benign` kwarg.
All 61 integration unit tests pass.